### PR TITLE
Add a way to debug individual sensors and adds a debug mode that enables print statements

### DIFF
--- a/.github/workflows/compile-sketch.yml
+++ b/.github/workflows/compile-sketch.yml
@@ -16,6 +16,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Copy config.h.example to config.h
+        run: cp src/config.h.example src/config.h
+
       # See: https://github.com/arduino/compile-sketches#readme
       - name: Compile sketches
         uses: arduino/compile-sketches@v1
@@ -47,4 +50,4 @@ jobs:
         with:
           sketches-reports-source: sketches-reports
           github-token: ${{ secrets.SPACE_API_KEY_GITHUB_PR }}
-          
+

--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,5 @@
 
 arduino.json
 c_cpp_properties.json
+settings.json
+config.h

--- a/README.md
+++ b/README.md
@@ -44,7 +44,12 @@ This project is in the process of being assembled. Code from other components ca
    ```
 2. Open the project in the Arduino IDE
 3. Install the necessary libraries
-4. Upload the code to your Arduino board
+4. **Configure your build options:**  
+   Copy the `config.h.example` file to `config.h` in the same directory. Edit `config.h` to enable or disable features (such as sensors and debug output) by changing the values from `1` (enabled) to `0` (disabled) as needed for your hardware setup.
+   ```bash
+   cp src/config.h.example src/config.h
+   ```
+5. Upload the code to your Arduino board
 
 ## Leffell Space Program Members
 - Raz Idan (Instructor)

--- a/src/config.h.example
+++ b/src/config.h.example
@@ -1,1 +1,6 @@
 #define debug 0 // Set to 1 to enable debug print messages, 0 to disable
+#define enable_MS5611 1 // Set to 1 to enable MS5611 barometer, 0 to disable
+#define enable_Ozone 1 // Set to 1 to enable Ozone sensor, 0 to disable
+#define enable_TempSensors 1 // Set to 1 to enable temperature sensors, 0 to disable
+#define enable_Sensirion 1 // Set to 1 to enable Sensirion SCD30 CO2 sensor, 0 to disable
+#define enable_buzzer 1 // Set to 1 to enable buzzer, 0 to disable

--- a/src/config.h.example
+++ b/src/config.h.example
@@ -1,0 +1,1 @@
+#define debug 0 // Set to 1 to enable debug print messages, 0 to disable

--- a/src/src.ino
+++ b/src/src.ino
@@ -7,35 +7,50 @@
 #include <MS5611.h>
 #include "DFRobot_OzoneSensor.h"
 #include <SensirionI2cScd30.h>
-#include <config.h>
+#include "config.h"
 
 TinyGPSPlus gps;
 
-#define INSIDE 5   //inside temp
-#define OUTSIDE 6  //outside temp
+#if enable_TempSensors
+  #define INSIDE 5   //inside temp
+  #define OUTSIDE 6  //outside temp
 
-// Setup a oneWire instance to communicate with any OneWire devices
-OneWire in(INSIDE);
-OneWire out(OUTSIDE);
+  // Setup a oneWire instance to communicate with any OneWire devices
+  OneWire in(INSIDE);
+  OneWire out(OUTSIDE);
 
-// Pass our oneWire reference to Dallas Temperature sensor
-DallasTemperature sensors_in(&in);
-DallasTemperature sensors_out(&out);
+  // Pass our oneWire reference to Dallas Temperature sensor
+  DallasTemperature sensors_in(&in);
+  DallasTemperature sensors_out(&out);
+#endif
 
 File myFile;
 
 String dataFile = "data.csv";
 
-#define COLLECT_NUMBER 20  // collect number, the collection range is 1-100
-#define Ozone_IICAddress OZONE_ADDRESS_3
-SensirionI2cScd30 sensor;
+#if enable_Ozone
+  #define COLLECT_NUMBER 20  // collect number, the collection range is 1-100
+  #define Ozone_IICAddress OZONE_ADDRESS_3
+#endif
 
-#define BUZZER_PIN 4  // Define buzzer pin
+#if enable_Sensirion
+  SensirionI2cScd30 sensor;
+#endif
 
-DFRobot_OzoneSensor Ozone;
+#if enable_buzzer
+  #define BUZZER_PIN 4  // Define buzzer pin
+#endif
 
-MS5611 baro;
-int32_t pressure;
+#if enable_Ozone
+  DFRobot_OzoneSensor Ozone;
+#endif
+
+#if enable_MS5611
+  MS5611 baro;
+#endif
+
+int32_t pressure = 0;
+int16_t ozoneConcentration = 0;
 float filtered = 0;
 float co2Concentration = 0;
 float temperature = 0;
@@ -66,11 +81,13 @@ void setup() {
     SD.begin(53);
   #endif
 
-  if (SD.exists(dataFile)) {
-    Serial.println("File exists");
-  } else {
-    Serial.println("Creating file");
-  }
+  #if debug
+    if (SD.exists(dataFile)) {
+      Serial.println("File exists");
+    } else {
+      Serial.println("Creating file");
+    }
+  #endif
 
   // Create/Open file
   myFile = SD.open(dataFile, FILE_WRITE);
@@ -78,37 +95,50 @@ void setup() {
     myFile.println("Time,Lat,Long,Alt,HDOP,Inside Temp,Outside Temp,Pressure,Ozone,CO2,Temperature,Humidity");
     myFile.flush();
     myFile.close();
-  #if debug
-    Serial.println("Header written to file");
-  #endif
+    #if debug
+      Serial.println("Header written to file");
+    #endif
   } else {
-  #if debug
-    Serial.println("Error opening file");
-  #endif
+    #if debug
+      Serial.println("Error opening file");
+    #endif
   }
   
   // Start barometer
   Wire.begin();
-  baro = MS5611();
-  baro.begin();
-  #if debug
+
+  #if enable_MS5611
+    baro = MS5611();
+    baro.begin();
+  #endif
+
+  #if debug && enable_Ozone
     if (!Ozone.begin(Ozone_IICAddress)) {
       Serial.println("Ozone sensor I2c device number error!");
     } else {
       Serial.println("Ozone sensor working");
     }
-  #else
+  #elif enable_Ozone
     Ozone.begin(Ozone_IICAddress);
   #endif
-  Ozone.setModes(MEASURE_MODE_PASSIVE);
+  #if enable_Ozone
+    Ozone.setModes(MEASURE_MODE_PASSIVE);
+  #endif
   
   // Start up the temperature sensors
-  sensors_in.begin();
-  sensors_out.begin();
+  #if enable_TempSensors
+    sensors_in.begin();
+    sensors_out.begin();
+  #endif
 
-  pinMode(BUZZER_PIN, OUTPUT);
-  sensor.begin(Wire, SCD30_I2C_ADDR_61);
-  sensor.startPeriodicMeasurement(0);  
+  #if enable_buzzer
+    pinMode(BUZZER_PIN, OUTPUT);
+  #endif
+
+  #if enable_Sensirion
+    sensor.begin(Wire, SCD30_I2C_ADDR_61);
+    sensor.startPeriodicMeasurement(0);  
+  #endif
 }
 
 void loop() {
@@ -143,21 +173,32 @@ void loop() {
     previousMillis = currentMillis;
     
     // Read pressure
-    pressure = baro.getPressure();
+    #if enable_MS5611
+      pressure = baro.getPressure();
+    #endif
+    
+    #if enable_Ozone
+      ozoneConcentration = Ozone.readOzoneData(COLLECT_NUMBER);
+    #endif
 
-    int16_t ozoneConcentration = Ozone.readOzoneData(COLLECT_NUMBER);
-    sensor.blockingReadMeasurementData(co2Concentration, temperature, humidity);
+    #if enable_Sensirion
+      sensor.blockingReadMeasurementData(co2Concentration, temperature, humidity);
+    #endif
 
-    sensors_in.requestTemperatures();
-    float insideCelsius = sensors_in.getTempCByIndex(0);
-    sensors_out.requestTemperatures();
-    float outsideCelsius = sensors_out.getTempCByIndex(0);
+    #if enable_TempSensors
+      sensors_in.requestTemperatures();
+      float insideCelsius = sensors_in.getTempCByIndex(0);
+      sensors_out.requestTemperatures();
+      float outsideCelsius = sensors_out.getTempCByIndex(0);
+    #endif
 
-    if (altitude < 300) {
-      digitalWrite(BUZZER_PIN, HIGH);
-    } else {
-      digitalWrite(BUZZER_PIN, LOW);
-    }
+    #if enable_buzzer
+      if (altitude < 300 && currentMillis > 30000) {
+        digitalWrite(BUZZER_PIN, HIGH);
+      } else {
+        digitalWrite(BUZZER_PIN, LOW);
+      }
+    #endif
 
     // Format and write data to SD
     String timeStr = String(hours < 10 ? "0" : "") + String(hours) + ":" + 

--- a/src/src.ino
+++ b/src/src.ino
@@ -7,6 +7,7 @@
 #include <MS5611.h>
 #include "DFRobot_OzoneSensor.h"
 #include <SensirionI2cScd30.h>
+#include <config.h>
 
 TinyGPSPlus gps;
 
@@ -55,11 +56,15 @@ void setup() {
   Serial1.begin(9600);  // Try different baud rate
   
   // SD Card Initialization
-  if (!SD.begin(53)) {
-    Serial.println("SD initialization failed!");
-  } else {
-    Serial.println("SD initialized successfully");
-  }
+  #if debug
+    if (!SD.begin(53)) {
+      Serial.println("SD initialization failed!");
+    } else {
+      Serial.println("SD initialized successfully");
+    }
+  #else 
+    SD.begin(53);
+  #endif
 
   if (SD.exists(dataFile)) {
     Serial.println("File exists");
@@ -73,21 +78,28 @@ void setup() {
     myFile.println("Time,Lat,Long,Alt,HDOP,Inside Temp,Outside Temp,Pressure,Ozone,CO2,Temperature,Humidity");
     myFile.flush();
     myFile.close();
+  #if debug
     Serial.println("Header written to file");
+  #endif
   } else {
+  #if debug
     Serial.println("Error opening file");
+  #endif
   }
   
   // Start barometer
   Wire.begin();
   baro = MS5611();
   baro.begin();
-
-  if (!Ozone.begin(Ozone_IICAddress)) {
-    Serial.println("Ozone sensor I2c device number error!");
-  } else {
-    Serial.println("Ozone sensor working");
-  }
+  #if debug
+    if (!Ozone.begin(Ozone_IICAddress)) {
+      Serial.println("Ozone sensor I2c device number error!");
+    } else {
+      Serial.println("Ozone sensor working");
+    }
+  #else
+    Ozone.begin(Ozone_IICAddress);
+  #endif
   Ozone.setModes(MEASURE_MODE_PASSIVE);
   
   // Start up the temperature sensors
@@ -167,11 +179,15 @@ void loop() {
     
     myFile = SD.open(dataFile, FILE_WRITE);
     if (myFile) {
-      Serial.println("Writing to SD: " + dataStr);
+      #if debug
+        Serial.println("Writing to SD: " + dataStr);
+      #endif
       myFile.println(dataStr);
       myFile.close();
     } else {
-      Serial.println("Error opening file for writing");
+      #if debug
+        Serial.println("Error opening file for writing");
+      #endif
     }
   }
 }


### PR DESCRIPTION
This PR adds a debug mode that enables print statements and introduces configuration flags through a new config header to allow toggling of sensor features, buzzer control, and debug logging. Key changes include:

- Inclusion of a configuration header ("config.h") for enabling/disabling sensors and debug output
- Conditional debug print statements in the SD card initialization and sensor setup
- Updated instructions and workflow steps to incorporate the new configuration file